### PR TITLE
support sasl authentication

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       KAFKA_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       HOSTNAME_COMMAND: hostname -i
-      KAFKA_LISTENERS: SASL_PLAINTEXT://kafka1:9092
-      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka1:9092
+      KAFKA_LISTENERS: PLAINTEXT://kafka1:9092,SASL_PLAINTEXT://kafka1:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092,SASL_PLAINTEXT://kafka1:9093
       KAFKA_NUM_PARTITIONS: 3
       KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
@@ -32,6 +32,7 @@ services:
       - "${GITHUB_WORKSPACE}:/kafka-client:rw"
     ports:
       - "9092:9092"
+      - "9093:9093"
 
   kafka2:
     container_name: kafka2
@@ -46,8 +47,8 @@ services:
       KAFKA_PORT: 9093
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       HOSTNAME_COMMAND: hostname -i
-      KAFKA_LISTENERS: SASL_PLAINTEXT://kafka2:9093
-      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka2:9093
+      KAFKA_LISTENERS: PLAINTEXT://kafka2:9094,SASL_PLAINTEXT://kafka1:9095
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9094,SASL_PLAINTEXT://kafka1:9095
       KAFKA_NUM_PARTITIONS: 3
       KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
       KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
@@ -58,7 +59,8 @@ services:
     volumes:
       - "${GITHUB_WORKSPACE}:/kafka-client:rw"
     ports:
-      - "9093:9093"
+      - "9094:9094"
+      - "9095:9095"
 
   swoole:
     container_name: "swoole"

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -19,9 +19,17 @@ services:
       KAFKA_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       HOSTNAME_COMMAND: hostname -i
-      KAFKA_LISTENERS: PLAINTEXT://kafka1:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092
+      KAFKA_LISTENERS: SASL_PLAINTEXT://kafka1:9092
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka1:9092
       KAFKA_NUM_PARTITIONS: 3
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      #      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SASL_PLAINTEXT
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/kafka-client/.github/kafka/jaas.conf"
+    command: "/kafka-client/.github/kafka/start_kafka.sh"
+    volumes:
+      - "${GITHUB_WORKSPACE}:/kafka-client:rw"
     ports:
       - "9092:9092"
 
@@ -38,9 +46,17 @@ services:
       KAFKA_PORT: 9093
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       HOSTNAME_COMMAND: hostname -i
-      KAFKA_LISTENERS: PLAINTEXT://kafka2:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9093
+      KAFKA_LISTENERS: SASL_PLAINTEXT://kafka2:9093
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka2:9093
       KAFKA_NUM_PARTITIONS: 3
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SASL_PLAINTEXT
+      #      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/kafka-client/.github/kafka/jaas.conf"
+    command: "/kafka-client/.github/kafka/start_kafka.sh"
+    volumes:
+      - "${GITHUB_WORKSPACE}:/kafka-client:rw"
     ports:
       - "9093:9093"
 

--- a/.github/kafka/jaas.conf
+++ b/.github/kafka/jaas.conf
@@ -1,0 +1,7 @@
+KafkaServer {
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="admin"
+    password="admin-secret"
+    user_admin="admin-secret"
+    user_alice="alice-secret";
+};

--- a/.github/kafka/start_kafka.sh
+++ b/.github/kafka/start_kafka.sh
@@ -1,0 +1,149 @@
+#!/bin/bash -e
+
+# Allow specific kafka versions to perform any unique bootstrap operations
+OVERRIDE_FILE="/opt/overrides/${KAFKA_VERSION}.sh"
+if [[ -x "$OVERRIDE_FILE" ]]; then
+    echo "Executing override file $OVERRIDE_FILE"
+    eval "$OVERRIDE_FILE"
+fi
+
+# Store original IFS config, so we can restore it at various stages
+ORIG_IFS=$IFS
+
+if [[ -z "$KAFKA_ZOOKEEPER_CONNECT" ]]; then
+    echo "ERROR: missing mandatory config: KAFKA_ZOOKEEPER_CONNECT"
+    exit 1
+fi
+
+if [[ -z "$KAFKA_PORT" ]]; then
+    export KAFKA_PORT=9092
+fi
+
+create-topics.sh &
+unset KAFKA_CREATE_TOPICS
+
+if [[ -z "$KAFKA_ADVERTISED_PORT" && \
+  -z "$KAFKA_LISTENERS" && \
+  -z "$KAFKA_ADVERTISED_LISTENERS" && \
+  -S /var/run/docker.sock ]]; then
+    KAFKA_ADVERTISED_PORT=$(docker port "$(hostname)" $KAFKA_PORT | sed -r 's/.*:(.*)/\1/g')
+    export KAFKA_ADVERTISED_PORT
+fi
+
+if [[ -z "$KAFKA_BROKER_ID" ]]; then
+    if [[ -n "$BROKER_ID_COMMAND" ]]; then
+        KAFKA_BROKER_ID=$(eval "$BROKER_ID_COMMAND")
+        export KAFKA_BROKER_ID
+    else
+        # By default auto allocate broker ID
+        export KAFKA_BROKER_ID=-1
+    fi
+fi
+
+if [[ -z "$KAFKA_LOG_DIRS" ]]; then
+    export KAFKA_LOG_DIRS="/kafka/kafka-logs-$HOSTNAME"
+fi
+
+if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
+    sed -r -i 's/(export KAFKA_HEAP_OPTS)="(.*)"/\1="'"$KAFKA_HEAP_OPTS"'"/g' "$KAFKA_HOME/bin/kafka-server-start.sh"
+    unset KAFKA_HEAP_OPTS
+fi
+
+if [[ -n "$HOSTNAME_COMMAND" ]]; then
+    HOSTNAME_VALUE=$(eval "$HOSTNAME_COMMAND")
+
+    # Replace any occurrences of _{HOSTNAME_COMMAND} with the value
+    IFS=$'\n'
+    for VAR in $(env); do
+        if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{HOSTNAME_COMMAND}" ]]; then
+            eval "export ${VAR//_\{HOSTNAME_COMMAND\}/$HOSTNAME_VALUE}"
+        fi
+    done
+    IFS=$ORIG_IFS
+fi
+
+if [[ -n "$PORT_COMMAND" ]]; then
+    PORT_VALUE=$(eval "$PORT_COMMAND")
+
+    # Replace any occurrences of _{PORT_COMMAND} with the value
+    IFS=$'\n'
+    for VAR in $(env); do
+        if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{PORT_COMMAND}" ]]; then
+	    eval "export ${VAR//_\{PORT_COMMAND\}/$PORT_VALUE}"
+        fi
+    done
+    IFS=$ORIG_IFS
+fi
+
+if [[ -n "$RACK_COMMAND" && -z "$KAFKA_BROKER_RACK" ]]; then
+    KAFKA_BROKER_RACK=$(eval "$RACK_COMMAND")
+    export KAFKA_BROKER_RACK
+fi
+
+# Try and configure minimal settings or exit with error if there isn't enough information
+if [[ -z "$KAFKA_ADVERTISED_HOST_NAME$KAFKA_LISTENERS" ]]; then
+    if [[ -n "$KAFKA_ADVERTISED_LISTENERS" ]]; then
+        echo "ERROR: Missing environment variable KAFKA_LISTENERS. Must be specified when using KAFKA_ADVERTISED_LISTENERS"
+        exit 1
+    elif [[ -z "$HOSTNAME_VALUE" ]]; then
+        echo "ERROR: No listener or advertised hostname configuration provided in environment."
+        echo "       Please define KAFKA_LISTENERS / (deprecated) KAFKA_ADVERTISED_HOST_NAME"
+        exit 1
+    fi
+
+    # Maintain existing behaviour
+    # If HOSTNAME_COMMAND is provided, set that to the advertised.host.name value if listeners are not defined.
+    export KAFKA_ADVERTISED_HOST_NAME="$HOSTNAME_VALUE"
+fi
+
+#Issue newline to config file in case there is not one already
+echo "" >> "$KAFKA_HOME/config/server.properties"
+
+(
+    function updateConfig() {
+        key=$1
+        value=$2
+        file=$3
+
+        # Omit $value here, in case there is sensitive information
+        echo "[Configuring] '$key' in '$file'"
+
+        # If config exists in file, replace it. Otherwise, append to file.
+        if grep -E -q "^#?$key=" "$file"; then
+            sed -r -i "s@^#?$key=.*@$key=$value@g" "$file" #note that no config values may contain an '@' char
+        else
+            echo "$key=$value" >> "$file"
+        fi
+    }
+
+    # Fixes #312
+    # KAFKA_VERSION + KAFKA_HOME + grep -rohe KAFKA[A-Z0-0_]* /opt/kafka/bin | sort | uniq | tr '\n' '|'
+    EXCLUSIONS="|KAFKA_VERSION|KAFKA_HOME|KAFKA_DEBUG|KAFKA_GC_LOG_OPTS|KAFKA_HEAP_OPTS|KAFKA_JMX_OPTS|KAFKA_JVM_PERFORMANCE_OPTS|KAFKA_LOG|KAFKA_OPTS|"
+
+    # Read in env as a new-line separated array. This handles the case of env variables have spaces and/or carriage returns. See #313
+    IFS=$'\n'
+    for VAR in $(env)
+    do
+        env_var=$(echo "$VAR" | cut -d= -f1)
+        if [[ "$EXCLUSIONS" = *"|$env_var|"* ]]; then
+            echo "Excluding $env_var from broker config"
+            continue
+        fi
+
+        if [[ $env_var =~ ^KAFKA_ ]]; then
+            kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ .)
+            updateConfig "$kafka_name" "${!env_var}" "$KAFKA_HOME/config/server.properties"
+        fi
+
+        if [[ $env_var =~ ^LOG4J_ ]]; then
+            log4j_name=$(echo "$env_var" | tr '[:upper:]' '[:lower:]' | tr _ .)
+            updateConfig "$log4j_name" "${!env_var}" "$KAFKA_HOME/config/log4j.properties"
+        fi
+    done
+)
+
+if [[ -n "$CUSTOM_INIT_SCRIPT" ]] ; then
+  eval "$CUSTOM_INIT_SCRIPT"
+fi
+
+exec "$KAFKA_HOME/bin/kafka-server-start.sh" "$KAFKA_HOME/config/server.properties"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       SWOOLE_VERSION: "4.5"
       KAFKA_HOST: kafka1
       KAFKA_PORT: 9092
+      KAFKA_SASL_PORT: 9093
       KAFKA_SASL: '{"type":"longlang\\phpkafka\\Sasl\\PlainSasl","username":"admin","password":"admin-secret"}'
 
     steps:
@@ -38,7 +39,13 @@ jobs:
           docker exec kafka1 /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
 
       - name: php-test
-        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION" -e KAFKA_SASL="$KAFKA_SASL" swoole composer test
+        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION" swoole composer test
 
       - name: swoole-test
-        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION"  -e KAFKA_SASL="$KAFKA_SASL" swoole composer swoole-test
+        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION"  swoole composer swoole-test
+
+      - name: php-test-sasl
+        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_SASL_PORT" -e KAFKA_VERSION="$KAFKA_VERSION" -e KAFKA_SASL="$KAFKA_SASL" swoole composer test
+
+      - name: swoole-test-sasl
+        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_SASL_PORT" -e KAFKA_VERSION="$KAFKA_VERSION"  -e KAFKA_SASL="$KAFKA_SASL" swoole composer swoole-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       KAFKA_VERSION: ${{ matrix.kafka }}
-      SWOOLE_VERSION: 4.5
+      SWOOLE_VERSION: "4.5"
       KAFKA_HOST: kafka1
       KAFKA_PORT: 9092
+      KAFKA_SASL: '{"type":"longlang\\phpkafka\\Sasl\\PlainSasl","username":"admin","password":"admin-secret"}'
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +38,7 @@ jobs:
           docker exec kafka1 /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
 
       - name: php-test
-        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION" swoole composer test
+        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION" -e KAFKA_SASL="$KAFKA_SASL" swoole composer test
 
       - name: swoole-test
-        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION" swoole composer swoole-test
+        run: docker exec -e KAFKA_HOST="$KAFKA_HOST" -e KAFKA_PORT="$KAFKA_PORT" -e KAFKA_VERSION="$KAFKA_VERSION"  -e KAFKA_SASL="$KAFKA_SASL" swoole composer swoole-test

--- a/README.cn.md
+++ b/README.cn.md
@@ -21,8 +21,8 @@ PHP Kafka 客户端，支持 PHP-FPM、Swoole 环境使用。
 - [x] PHP-FPM、Swoole 智能环境识别兼容
 - [x] 生产者类
 - [x] 消费者类
+- [x] SASL 鉴权
 - [ ] SSL 加密通信
-- [ ] SASL 鉴权
 - [ ] 更多功能的封装及测试用例编写
 
 ## 环境要求

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The communication protocol is based on the JSON file in Java. PHP Kafka client s
 - [x] PHP-FPM and Swoole compatible
 - [x] Producer
 - [x] Consumer
+- [x] SASL
 - [ ] SSL
-- [ ] SASL
 - [ ] More features and test cases
 
 ## Environment

--- a/doc/consumer.en.md
+++ b/doc/consumer.en.md
@@ -40,6 +40,7 @@ Class `longlang\phpkafka\Consumer\ConsumerConfig`
 | minBytes | Min bytes | `1` |
 | maxBytes | Max bytes | `128 * 1024 * 1024` |
 | maxWait | The maximum time. (unit: second, decimal) | `1` |
+| sasl |  SASL authentication Info. If the field is null, it will not authenticate with SASL [detail](#SASL-Support) | `[]`|
 
 ## Asynchronous (callback)
 
@@ -90,3 +91,28 @@ while(true) {
     sleep(1);
 }
 ```
+
+## SASL Support
+### Configuration
+| Key | Description | Default |
+| - | - | - |
+| type | SASL Authentication Type. PLAIN is ``\longlang\phpkafka\Sasl\PlainSasl::class``| ''|
+| username | username  | '' |
+| password | password  | '' |
+
+**Example**
+```php
+use longlang\phpkafka\Consumer\Consumer;
+use longlang\phpkafka\Consumer\ConsumerConfig;
+
+$config = new ConsumerConfig();
+// .... Your Othor Config
+$config->setSasl([
+    "type"=>\longlang\phpkafka\Sasl\PlainSasl::class,
+    "username"=>"admin",
+    "password"=>"admin-secret"
+]);
+$consumer = new Consumer($config);
+// ....  Your Business Code
+```
+

--- a/doc/consumer.md
+++ b/doc/consumer.md
@@ -40,6 +40,7 @@
 | minBytes | 最小字节数 | `1` |
 | maxBytes | 最大字节数 | `128 * 1024 * 1024` |
 | maxWait | 最大等待时间，单位：秒 | `1` |
+| sasl | SASL身份认证信息。为空则不发送身份认证信息 [详情](#SASL支持) | `[]`|
 
 ## 异步消费（回调）
 
@@ -89,4 +90,28 @@ while(true) {
     }
     sleep(1);
 }
+```
+
+## SASL支持
+### 相关配置
+|参数名|说明|默认值|
+| - | - | - |
+| type | SASL授权对应的类。PLAIN为``\longlang\phpkafka\Sasl\PlainSasl::class``| ''|
+| username | 账号 | '' |
+| password | 密码 | '' |
+
+**代码示例：**
+```php
+use longlang\phpkafka\Consumer\Consumer;
+use longlang\phpkafka\Consumer\ConsumerConfig;
+
+$config = new ConsumerConfig();
+// .... 你的其他配置
+$config->setSasl([
+    "type"=>\longlang\phpkafka\Sasl\PlainSasl::class,
+    "username"=>"admin",
+    "password"=>"admin-secret"
+]);
+$consumer = new Consumer($config);
+// ....  你的业务代码
 ```

--- a/doc/producer.en.md
+++ b/doc/producer.en.md
@@ -29,6 +29,7 @@ Class `longlang\phpkafka\Producer\ProducerConfig`
 | partitioner | Partitioning strategy |  Default: `\longlang\phpkafka\Producer\Partitioner\DefaultPartitioner` |
 | produceRetry | Produce message retries allowed if matching an error code. | `3` |
 | produceRetrySleep | Produce message retry sleep time. (unit: second) | `0.1` |
+| sasl |  SASL authentication Info. If the field is null, it will not authenticate with SASL [detail](#SASL-Support) | `[]`|
 
 **Default partitioning strategy：**
 
@@ -78,4 +79,27 @@ $producer->sendBatch([
     new ProduceMessage($topic, 'v1', 'k1', $partition0),
     new ProduceMessage($topic, 'v2', 'k2', $partition1),
 ]);
+```
+
+## SASL Support
+### Configuration
+| Key | Description | Default |
+| - | - | - |
+| type | SASL Authentication Type. PLAIN is ``\longlang\phpkafka\Sasl\PlainSasl::class``| ''|
+| username | username  | '' |
+| password | password  | '' |
+
+**Example**
+```php
+use longlang\phpkafka\Producer\ProducerConfig;
+
+$config = new ProducerConfig();
+// .... Your Other Config
+$config->setSasl([
+    "type"=>\longlang\phpkafka\Sasl\PlainSasl::class,
+    "username"=>"admin",
+    "password"=>"admin-secret"
+]);
+$producer = new Producer($config);
+// ....  Your Business Code
 ```

--- a/doc/producer.md
+++ b/doc/producer.md
@@ -29,6 +29,7 @@
 | partitioner | 分区策略 |  默认策略：`\longlang\phpkafka\Producer\Partitioner\DefaultPartitioner` |
 | produceRetry | 生产消息，匹配预设的错误码时，自动重试次数 | `3` |
 | produceRetrySleep | 生产消息重试延迟，单位：秒 | `0.1` |
+| sasl | SASL身份认证信息。为空则不发送身份认证信息 [详情](#SASL支持) | `[]`|
 
 **默认分区策略：**
 
@@ -78,4 +79,29 @@ $producer->sendBatch([
     new ProduceMessage($topic, 'v1', 'k1', $partition0),
     new ProduceMessage($topic, 'v2', 'k2', $partition1),
 ]);
+```
+
+
+
+## SASL支持
+### 相关配置
+|参数名|说明|默认值|
+| - | - | - |
+| type | SASL授权对应的类。PLAIN为``\longlang\phpkafka\Sasl\PlainSasl::class``| ''|
+| username | 账号 | '' |
+| password | 密码 | '' |
+
+**代码示例：**
+```php
+use longlang\phpkafka\Producer\ProducerConfig;
+
+$config = new ProducerConfig();
+// .... 你的其他配置
+$config->setSasl([
+    "type"=>\longlang\phpkafka\Sasl\PlainSasl::class,
+    "username"=>"admin",
+    "password"=>"admin-secret"
+]);
+$producer = new Producer($config);
+// ....  你的业务代码
 ```

--- a/src/Config/CommonConfig.php
+++ b/src/Config/CommonConfig.php
@@ -54,6 +54,11 @@ class CommonConfig extends AbstractConfig
      */
     protected $exceptionCallback = null;
 
+    /**
+     * @var array
+     */
+    protected $sasl = [];
+
     public function getConnectTimeout(): float
     {
         return $this->connectTimeout;
@@ -170,5 +175,15 @@ class CommonConfig extends AbstractConfig
         $this->exceptionCallback = $exceptionCallback;
 
         return $this;
+    }
+
+    public function getSasl(): array
+    {
+        return $this->sasl;
+    }
+
+    public function setSasl(array $sasl): void
+    {
+        $this->sasl = $sasl;
     }
 }

--- a/src/Config/CommonConfig.php
+++ b/src/Config/CommonConfig.php
@@ -182,8 +182,10 @@ class CommonConfig extends AbstractConfig
         return $this->sasl;
     }
 
-    public function setSasl(array $sasl): void
+    public function setSasl(array $sasl): self
     {
         $this->sasl = $sasl;
+
+        return $this;
     }
 }

--- a/src/Sasl/PlainSasl.php
+++ b/src/Sasl/PlainSasl.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace longlang\phpkafka\Sasl;
+
+use longlang\phpkafka\Config\CommonConfig;
+use longlang\phpkafka\Exception\KafkaErrorException;
+
+class PlainSasl implements SaslInterface
+{
+    /**
+     * @var CommonConfig
+     */
+    protected $config;
+
+    public function __construct(CommonConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * 授权模式.
+     */
+    public function getName(): string
+    {
+        return 'PLAIN';
+    }
+
+    /**
+     * 获得加密串.
+     */
+    public function getAuthBytes(): string
+    {
+        $config = $this->config->getSasl();
+        if (empty($config['username']) || empty($config['password'])) {
+            // 不存在就报错
+            throw new KafkaErrorException('sasl not found auth info');
+        }
+
+        return sprintf("\x00%s\x00%s", $config['username'], $config['password']);
+    }
+}

--- a/src/Sasl/SaslInterface.php
+++ b/src/Sasl/SaslInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace longlang\phpkafka\Sasl;
+
+use longlang\phpkafka\Config\CommonConfig;
+
+interface SaslInterface
+{
+    public function __construct(CommonConfig $config);
+
+    /**
+     * 获得授权名称.
+     */
+    public function getName(): string;
+
+    /**
+     * 返回授权信息.
+     */
+    public function getAuthBytes(): string;
+}

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -15,6 +15,7 @@ class ConsumerTest extends TestCase
     {
         $config = new ConsumerConfig();
         $config->setBroker(TestUtil::getHost() . ':' . TestUtil::getPort());
+        $config->setSasl(TestUtil::getSasl());
         $config->setTopic('test');
         $config->setGroupId('testGroup');
         $config->setClientId('testConsumeWithRangeAssignor');
@@ -34,6 +35,7 @@ class ConsumerTest extends TestCase
     {
         $config = new ConsumerConfig();
         $config->setBroker(TestUtil::getHost() . ':' . TestUtil::getPort());
+        $config->setSasl(TestUtil::getSasl());
         $config->setTopic('test');
         $config->setGroupId('testGroup');
         $config->setClientId('testConsumeWithRoundRobinAssignor');
@@ -53,6 +55,7 @@ class ConsumerTest extends TestCase
     {
         $config = new ConsumerConfig();
         $config->setBroker([TestUtil::getHost() . ':' . TestUtil::getPort()]);
+        $config->setSasl(TestUtil::getSasl());
         $config->setTopic('test');
         $config->setGroupId('testGroup');
         $config->setClientId('testConsumeWithStickyAssignor');

--- a/tests/ProducerTest.php
+++ b/tests/ProducerTest.php
@@ -15,6 +15,7 @@ class ProducerTest extends TestCase
     {
         $config = new ProducerConfig();
         $config->setBootstrapServer(TestUtil::getHost() . ':' . TestUtil::getPort());
+        $config->setSasl(TestUtil::getSasl());
         $config->setAcks(-1);
         $producer = new Producer($config);
         $producer->send('test', (string) microtime(true), uniqid('', true), [], 0);
@@ -30,6 +31,7 @@ class ProducerTest extends TestCase
     {
         $config = new ProducerConfig();
         $config->setBootstrapServer(TestUtil::getHost() . ':' . TestUtil::getPort());
+        $config->setSasl(TestUtil::getSasl());
         $config->setAcks(-1);
         $producer = new Producer($config);
         $producer->sendBatch([

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -24,7 +24,14 @@ class TestUtil
 
     public static function getPort(): int
     {
-        return (int) (getenv('KAFKA_PORT') ?: 9092);
+        return (int) (getenv('KAFKA_PORT') ?: 9090);
+    }
+
+    public static function getSasl(): array
+    {
+        $result = getenv('KAFKA_SASL') ?: '{}';
+
+        return json_decode($result, true);
     }
 
     public static function createKafkaClient(string $class = null): ClientInterface
@@ -32,6 +39,7 @@ class TestUtil
         $config = new CommonConfig();
         $config->setSendTimeout(10);
         $config->setRecvTimeout(10);
+        $config->setSasl(self::getSasl());
         if (null === $class) {
             $class = getenv('KAFKA_CLIENT_CLASS') ?: SyncClient::class;
         }
@@ -42,6 +50,8 @@ class TestUtil
     public static function getControllerClient(): ClientInterface
     {
         $client = self::createKafkaClient();
+        //$client->getConfig()->setSa
+        //sl([]);
         $client->connect();
         $request = new MetadataRequest();
         /** @var MetadataResponse $response */
@@ -51,6 +61,7 @@ class TestUtil
         $config = new CommonConfig();
         $config->setSendTimeout(10);
         $config->setRecvTimeout(10);
+        $config->setSasl(self::getSasl());
         $class = getenv('KAFKA_CLIENT_CLASS') ?: SyncClient::class;
         $nodeId = $response->getControllerId();
         foreach ($response->getBrokers() as $broker) {
@@ -80,6 +91,7 @@ class TestUtil
                         $config = new CommonConfig();
                         $config->setSendTimeout(10);
                         $config->setRecvTimeout(10);
+                        $config->setSasl(self::getSasl());
                         $class = getenv('KAFKA_CLIENT_CLASS') ?: SyncClient::class;
                         $nodeId = $partitionItem->getLeaderId();
                         foreach ($response->getBrokers() as $broker) {

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -24,7 +24,7 @@ class TestUtil
 
     public static function getPort(): int
     {
-        return (int) (getenv('KAFKA_PORT') ?: 9090);
+        return (int) (getenv('KAFKA_PORT') ?: 9092);
     }
 
     public static function getSasl(): array
@@ -50,8 +50,6 @@ class TestUtil
     public static function getControllerClient(): ClientInterface
     {
         $client = self::createKafkaClient();
-        //$client->getConfig()->setSa
-        //sl([]);
         $client->connect();
         $request = new MetadataRequest();
         /** @var MetadataResponse $response */


### PR DESCRIPTION
支持了SASL鉴权

目前只实现了``PLAIN``方式鉴权。可扩展。

SASL目前是一个数组
~~~ php
$sasl = [
    "type"=> longlang\\phpkafka\\Sasl\\PlainSasl::class, // 这个就是确定通过哪个方式鉴权
    ... 剩下的信息是鉴权信息，不同的鉴权的类不一样
]
~~~

修改了单元测试。由于kafka的Docker镜像在1.0.0和2.x启动脚本不一样。导致无法环境变量无法兼容。现在kafka的启动脚本是从官方最新的master分支拷贝出来的