### PR TITLE
fix: 🐛 swoole client

### DIFF
--- a/src/Client/SwooleClient.php
+++ b/src/Client/SwooleClient.php
@@ -149,6 +149,7 @@ class SwooleClient extends SyncClient
                     $callback = $this->getConfig()->getExceptionCallback();
                     if ($callback) {
                         $callback($e);
+                        return;
                     } else {
                         throw $e;
                     }


### PR DESCRIPTION
修复 swoole client starRecvCo 设置了exception callback 时会死循环

✅ Closes: #64