### PR TITLE
修复 producer 报错 Could not recv data from stream 和 producer 死循环

### DIFF
--- a/src/Client/SwooleClient.php
+++ b/src/Client/SwooleClient.php
@@ -146,6 +146,10 @@ class SwooleClient extends SyncClient
                     if ($e instanceof SocketException && !$this->connected) {
                         return;
                     }
+                    if ($e instanceof SocketException && $this->connected) {
+                        $this->socket->close();
+                        break;
+                    }
                     $callback = $this->getConfig()->getExceptionCallback();
                     if ($callback) {
                         $callback($e);


### PR DESCRIPTION
1. 修复生产者报错 Could not recv data from stream
2. 修复当 ->setAutoCreateTopic(false) 时，生产一个不存在的 topic 导致死循环最后内存溢出