### PR TITLE
Fix errors in non-swoole environments

### DIFF
--- a/src/Socket/StreamSocket.php
+++ b/src/Socket/StreamSocket.php
@@ -231,9 +231,10 @@ class StreamSocket implements SocketInterface
         $null = [];
         $timeoutSec = (int) $timeout;
         if ($timeoutSec < 0) {
-            $timeoutSec = null;
+            $timeoutSec = $timeoutUsec = null;
+        } else {
+            $timeoutUsec = max((int) (1000000 * ($timeout - $timeoutSec)), 0);
         }
-        $timeoutUsec = max((int) (1000000 * ($timeout - $timeoutSec)), 0);
 
         if ($isRead) {
             return stream_select($sockets, $null, $null, $timeoutSec, $timeoutUsec);

--- a/src/Util/KafkaUtil.php
+++ b/src/Util/KafkaUtil.php
@@ -74,6 +74,6 @@ class KafkaUtil
 
     public static function inSwooleCoroutine(): bool
     {
-        return method_exists(Coroutine::class, 'getCid') && -1 !== Coroutine::getCid();
+        return extension_loaded('swoole') && method_exists(Coroutine::class, 'getCid') && -1 !== Coroutine::getCid();
     }
 }


### PR DESCRIPTION
fix
```shell
[ERROR] ErrorException: stream_select(): Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null in /Users/demo/vendor/longlang/phpkafka/src/Socket/StreamSocket.php:252
```