### PR TITLE
对于 topic 不存在时获取 meta 信息直接抛出异常(移除重试)

### DIFF
--- a/src/Broker.php
+++ b/src/Broker.php
@@ -124,7 +124,6 @@ class Broker
                 $topicsMeta[] = $topicItem;
             } else {
                 switch ($topicItem->getErrorCode()) {
-                    case ErrorCode::UNKNOWN_TOPIC_OR_PARTITION:
                     case ErrorCode::LEADER_NOT_AVAILABLE:
                         $retryTopics[] = $topicItem->getName();
                         break;


### PR DESCRIPTION
当生产者关闭自动创建 topic 参数设置，然后发起投递时会出现获取 topic meta 数据一直重试问题，代码在此陷入递归死循环。基于有问题尽早抛出原则，建议移除 `ErrorCode::UNKNOWN_TOPIC_OR_PARTITION` 这个 case 分支，直接抛出异常。