### PR TITLE
Fix: Timer::tick callback throw exception cause process exit

### DIFF
--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -383,7 +383,14 @@ class Consumer
     protected function startHeartbeat(): void
     {
         $this->heartbeatTimerId = $this->timer->tick((int) ($this->config->getGroupHeartbeat() * 1000), function () {
-            $this->heartbeat();
+            try {
+                $this->heartbeat();
+            } catch (KafkaErrorException $e) {
+                $callback = $this->getConfig()->getExceptionCallback();
+                if ($callback) {
+                    $callback($e);
+                }
+            }
         });
     }
 


### PR DESCRIPTION
Swoole\Coroutine\Server
![image](https://github.com/swoole/phpkafka/assets/17758819/f3843da2-8f58-43f6-954e-3c889d4a1ca2)
