### PR TITLE
Fix:  Exception: setTopicName(): Argument #1 ($topicName) must be of type string, int given

### DIFF
--- a/src/Consumer/Assignor/RangeAssignor.php
+++ b/src/Consumer/Assignor/RangeAssignor.php
@@ -64,7 +64,7 @@ class RangeAssignor extends AbstractPartitionAssignor
                 /** @var ConsumerGroupMemberAssignment $consumerGroupMemberAssignment */
                 $consumerGroupMemberAssignment = $topicMembers[$topicName][$memberIds[$i]]['assignment'];
                 $consumerGroupTopic = new ConsumerGroupTopic();
-                $consumerGroupTopic->setTopicName($topicName);
+                $consumerGroupTopic->setTopicName((string) $topicName);
                 $consumerGroupTopic->setPartitions(\array_slice($topicPartitions, $start, $length));
                 $topics = $consumerGroupMemberAssignment->getTopics();
                 $topics[] = $consumerGroupTopic;


### PR DESCRIPTION
Exception: longlang\phpkafka\Group\Struct\ConsumerGroupTopic::setTopicName(): Argument #1 ($topicName) must be of type string, int given

$partitions[$topic] = $this->getTopicPartitions($topic, $topicMetadatas);

Strings containing valid decimal ints, unless the number is preceded by a + sign, will be cast to the int type. E.g. the key "8" will actually be stored under 8. On the other hand "08" will not be cast, as it isn't a valid decimal integer.