### PR TITLE
fix(inifinty-loop): updateMetadata avoid infinity-loop

### DIFF
--- a/src/Broker.php
+++ b/src/Broker.php
@@ -144,7 +144,7 @@ class Broker
             $this->metaUpdatedTopics = $topics;
         }
 
-        if ($retryTopics && ($this->config->getMaxTopicFetchRetry() < 0 || $this->config->getMaxTopicFetchRetry() <= $retry)) {
+        if ($retryTopics && ($this->config->getMaxTopicFetchRetry() < 0 || $this->config->getMaxTopicFetchRetry() > $retry)) {
             return $this->updateMetadata($retryTopics, $client, $retry + 1);
         }
 

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -101,7 +101,7 @@ class Broker
         $this->setBrokers($brokers);
     }
 
-    public function updateMetadata(array $topics = [], ?ClientInterface $client = null): MetadataResponse
+    public function updateMetadata(array $topics = [], ?ClientInterface $client = null, int $retry = 0): MetadataResponse
     {
         if (null === $client) {
             $client = $this->getClient();
@@ -144,8 +144,8 @@ class Broker
             $this->metaUpdatedTopics = $topics;
         }
 
-        if ($retryTopics) {
-            return $this->updateMetadata($retryTopics, $client);
+        if ($retryTopics && ($this->config->getMaxTopicFetchRetry() < 0 || $this->config->getMaxTopicFetchRetry() <= $retry)) {
+            return $this->updateMetadata($retryTopics, $client, $retry + 1);
         }
 
         return $response;

--- a/src/Config/CommonConfig.php
+++ b/src/Config/CommonConfig.php
@@ -64,6 +64,11 @@ class CommonConfig extends AbstractConfig
      */
     protected $ssl = null;
 
+    /**
+     * @var int
+     */
+    protected $maxTopicFetchRetry = -1;
+
     public function getConnectTimeout(): float
     {
         return $this->connectTimeout;
@@ -215,6 +220,18 @@ class CommonConfig extends AbstractConfig
         } else {
             throw new InvalidArgumentException(sprintf('The ssl must be array or SslConfig, and the current type is %s', \gettype($ssl)));
         }
+
+        return $this;
+    }
+
+    public function getMaxTopicFetchRetry(): int
+    {
+        return $this->maxTopicFetchRetry;
+    }
+
+    public function setMaxTopicFetchRetry(int $maxTopicFetchRetry): self
+    {
+        $this->maxTopicFetchRetry = $maxTopicFetchRetry;
 
         return $this;
     }


### PR DESCRIPTION
Under certain conditions updateMetadata may produce an infinite loop.
If the topic does not exist and topic autocreation is not enabled, the Producer tries to send a message and updateMetadata continues to fetch topics indefinitely.