### PR TITLE
在心跳处理,增加链接重连

### DIFF
--- a/src/Util/KafkaUtil.php
+++ b/src/Util/KafkaUtil.php
@@ -66,6 +66,7 @@ class KafkaUtil
         }
         $errorCode = $response->getErrorCode();
         if (!ErrorCode::success($errorCode)) {
+            $client->close();
             if ($retry > 0 && ErrorCode::canRetry($errorCode)) {
                 if ($sleep > 0) {
                     usleep((int) ($sleep * 1000000));


### PR DESCRIPTION
解决一直报错和不能正常消费问题
```
[WARNING] [AbstractProcess@anonymous\/vendor/hyperf/kafka/src/ConsumerManager.php:81$16a::handle] longlang\phpkafka\Exception\KafkaErrorException: [25] The coordinator is not aware of this member. in vendor/longlang/phpkafka/src/Protocol/ErrorCode.php:385
```